### PR TITLE
ci(rspec): cache dependencies for tests.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
+      - '.github/workflows/rspec.yml'
       - 'lib/**'
       - 'spec/**'
       - 'warframe.gemspec'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,9 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
+          bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - run: |
-          gem install bundler
-          bundle config unset deployment
-          bundle install
-          bundle exec rspec
+      - run: bundle exec rspec


### PR DESCRIPTION
* Uses the `bundler-cache` option to cache dependencies.